### PR TITLE
Be able to use rustest in unit tests.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ fn RunningProcess(cmd: Command) -> std::io::Result<Box<std::process::Child>> {
 }
 ```
 
-I have found not test framework allowing to have teardown on global fixtures.
+I have found no test framework allowing to have teardown on global fixtures.
 Storing the running process in a static LazyLock allow to have a simple "fixture" but, as statics are not drop, no
 teardown either.
 
@@ -75,10 +75,21 @@ harness = false
 [[test]]
 name = "other_test" # for a test located at "tests/other_test.rs"
 harness = false
+
+# For unit test, you also need to deactivate harness for lib
+[lib]
+harness = false
 ```
 
 You also need to add a main function in each of your integration tests. To do so add an empty main function and
 mark it with `#[rustest::main]` attribute.
+For unit testing, add the main function at end of you `lib.rs` file, under a `cfg(test)` flag:
+
+```rust
+#[cfg(test)]
+#[rustest::main]
+fn main () {}
+```
 
 
 ## Usage Examples

--- a/rustest/Cargo.toml
+++ b/rustest/Cargo.toml
@@ -11,6 +11,7 @@ categories.workspace = true
 keywords.workspace = true
 
 [dependencies]
+ctor = { version = "0.4.1", features = ["__no_warn_on_missing_unsafe"] }
 libtest-mimic = "0.8.1"
 rustest-macro = { version = "0.1.0", path = "../rustest-macro" }
 

--- a/rustest/src/lib.rs
+++ b/rustest/src/lib.rs
@@ -10,29 +10,31 @@ pub use fixture::{Fixture, FixtureCreationError, FixtureDisplay, FixtureMatrix, 
 pub use test::{InnerTestResult, IntoError};
 pub use test::{Result, Test, TestContext};
 
+pub use ctor::declarative::ctor;
+
 /// Function creating a set of [Test] from a [TestContext].
 ///
 /// Classic function will resolve fixture matrix and generate a [Test] per combination.
 /// Such functions are implement by [test]
-pub type TestCtorFn =
+pub type TestGeneratorFn =
     fn(&mut TestContext) -> ::std::result::Result<Vec<Test>, FixtureCreationError>;
 
 /// Build tests from `test_ctors` and run them.
 ///
 /// You should not directly call it directly.
 /// Use [main] attribute on an empty main function.
-pub fn run_tests(test_ctors: &[TestCtorFn]) -> std::process::ExitCode {
+pub fn run_tests(test_generators: &[TestGeneratorFn]) -> std::process::ExitCode {
     use libtest_mimic::{Arguments, run};
     let args = Arguments::from_args();
 
     let mut global_registry = FixtureRegistry::new();
 
-    let tests: ::std::result::Result<Vec<_>, FixtureCreationError> = test_ctors
+    let tests: ::std::result::Result<Vec<_>, FixtureCreationError> = test_generators
         .iter()
-        .map(|test_ctor| {
+        .map(|test_generator| {
             let mut test_registry = FixtureRegistry::new();
             let mut ctx = TestContext::new(&mut global_registry, &mut test_registry);
-            test_ctor(&mut ctx)
+            test_generator(&mut ctx)
         })
         .collect();
 


### PR DESCRIPTION
To do so, we have to be able to register tests from any module.