### PR TITLE
add example of sequential test

### DIFF
--- a/rustest-testing/src/lib.rs
+++ b/rustest-testing/src/lib.rs
@@ -1,4 +1,5 @@
 mod other_mod;
+mod sequential;
 
 pub use other_mod::*;
 

--- a/rustest-testing/src/sequential.rs
+++ b/rustest-testing/src/sequential.rs
@@ -1,0 +1,113 @@
+//! Example showing how to write sequentially executed tests.
+//! `sleep` is used to introduce artificial delay and the unix timestamp is printed to show that
+//! they indeed run sequentially with no overlap in execution time.
+
+use std::thread::sleep;
+use std::time::Duration;
+
+pub struct Client {}
+
+impl Client {
+    pub fn new() -> Self {
+        println!("Hello, world!");
+        Self {}
+    }
+    pub fn add(&self, left: u64, right: u64) -> u64 {
+        sleep(Duration::from_millis(100));
+        left + right
+    }
+}
+
+impl Drop for Client {
+    fn drop(&mut self) {
+        println!("goodbye!");
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use googletest::prelude::*;
+    use rustest::{FixtureDisplay, fixture, test};
+    use std::ops::Deref;
+    use std::sync::Mutex;
+    use std::thread::sleep;
+    use std::time::{Duration, UNIX_EPOCH};
+
+    struct ClientWrapper(pub super::Client);
+
+    impl Deref for ClientWrapper {
+        type Target = super::Client;
+        fn deref(&self) -> &Self::Target {
+            &self.0
+        }
+    }
+
+    #[fixture(scope=global)]
+    fn Client() -> Mutex<ClientWrapper> {
+        Mutex::new(ClientWrapper(super::Client::new()))
+    }
+
+    impl FixtureDisplay for ClientWrapper {
+        fn display(&self) -> String {
+            "client".to_string()
+        }
+    }
+
+    #[test]
+    fn test1(client: Client) {
+        let client = client.lock().unwrap();
+        println!(
+            "1: {}",
+            std::time::SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_micros()
+        );
+        let result = client.add(2, 2);
+        println!(
+            "1: {}",
+            std::time::SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_micros()
+        );
+        sleep(Duration::from_millis(200));
+        println!(
+            "1: {}",
+            std::time::SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_micros()
+        );
+        assert_that!(result, eq(4));
+    }
+
+    #[test]
+    fn test2(client: Client) {
+        let client = client.lock().unwrap();
+        println!(
+            "2: {}",
+            std::time::SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_micros()
+        );
+        let result = client.add(2, 2);
+        println!(
+            "2: {}",
+            std::time::SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_micros()
+        );
+        sleep(Duration::from_millis(200));
+        println!(
+            "2: {}",
+            std::time::SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_micros()
+        );
+        assert_that!(result, eq(4));
+    }
+}


### PR DESCRIPTION
note that this test itself doesn't verify that it is really being run sequentially: i couldn't come up with a good idea how to do that without introducing another potentially locking functionality (i contemplated using a `static` `AtomicBool` but that might also inadvertently serialise the test even if the sequentiality of the `Mutex` is broken?).

this is more meant as a showcase of how it can be done and not as a self-test of `rustest` since - at least at the moment - `rustest` does not offer sequential tests as a feature itself.

see #16 for further information