### PR TITLE
Add support for (conditional) ignore.

### DIFF
--- a/rustest-fixtures/src/global.rs
+++ b/rustest-fixtures/src/global.rs
@@ -65,22 +65,20 @@ impl<Source: SubFixture> rustest::FixtureBuilder for GlobalBuilder<Source> {
     type Type = Source::Type;
     const SCOPE: rustest::FixtureScope = rustest::FixtureScope::Global;
 
-    fn setup(
-        ctx: &mut rustest::TestContext,
-    ) -> std::result::Result<Vec<Self>, rustest::FixtureCreationError>
+    fn setup(ctx: &mut rustest::TestContext) -> Vec<Self>
     where
         Self: Sized,
     {
         if let Some(b) = ctx.get() {
-            return Ok(b);
+            return b;
         }
-        let builders: Vec<_> = Source::Builder::setup(ctx)?
+        let builders: Vec<_> = Source::Builder::setup(ctx)
             .into_iter()
             .map(|b| Self(b))
             .collect();
 
         ctx.add::<Self>(builders.duplicate());
-        Ok(builders)
+        builders
     }
 
     fn build(&self) -> std::result::Result<Self::Fixt, rustest::FixtureCreationError>

--- a/rustest-fixtures/src/global.rs
+++ b/rustest-fixtures/src/global.rs
@@ -81,7 +81,7 @@ impl<Source: SubFixture> rustest::FixtureBuilder for GlobalBuilder<Source> {
         builders
     }
 
-    fn build(&self) -> std::result::Result<Self::Fixt, rustest::FixtureCreationError>
+    fn build(&self) -> rustest::FixtureCreationResult<Self::Fixt>
     where
         Self: Sized,
     {

--- a/rustest-fixtures/src/tempfile.rs
+++ b/rustest-fixtures/src/tempfile.rs
@@ -49,7 +49,7 @@ impl rustest::FixtureBuilder for TempFileBuilder {
         vec![Self]
     }
 
-    fn build(&self) -> Result<Self::Fixt, rustest::FixtureCreationError> {
+    fn build(&self) -> rustest::FixtureCreationResult<Self::Fixt> {
         Ok(TempFile(
             tempfile::NamedTempFile::new_in(std::env::temp_dir())
                 .map_err(|e| rustest::FixtureCreationError::new("TempFile", e))?,

--- a/rustest-fixtures/src/tempfile.rs
+++ b/rustest-fixtures/src/tempfile.rs
@@ -42,13 +42,11 @@ impl rustest::FixtureBuilder for TempFileBuilder {
     type Type = tempfile::NamedTempFile;
     const SCOPE: FixtureScope = FixtureScope::Unique;
 
-    fn setup(
-        _ctx: &mut rustest::TestContext,
-    ) -> std::result::Result<Vec<Self>, rustest::FixtureCreationError>
+    fn setup(_ctx: &mut rustest::TestContext) -> Vec<Self>
     where
         Self: Sized,
     {
-        Ok(vec![Self])
+        vec![Self]
     }
 
     fn build(&self) -> Result<Self::Fixt, rustest::FixtureCreationError> {

--- a/rustest-macro/src/fixture.rs
+++ b/rustest-macro/src/fixture.rs
@@ -241,7 +241,7 @@ pub(crate) fn fixture_impl(args: FixtureAttr, input: ItemFn) -> Result<TokenStre
             }
             fn build_fixt(
                 #sub_fixtures_call_args : ::rustest::CallArgs<Self::SubFixtures>,
-            ) -> std::result::Result<<Self::Fixt as ::rustest::Fixture>::Type, ::rustest::FixtureCreationError> {
+            ) -> ::rustest::FixtureCreationResult<<Self::Fixt as ::rustest::Fixture>::Type> {
                 use ::rustest::FixtureBuilder;
                 #use_param
                 fn user_provided_setup #fixture_generics (#sig_inputs) #builder_output #where_clause

--- a/rustest-macro/src/fixture.rs
+++ b/rustest-macro/src/fixture.rs
@@ -234,10 +234,10 @@ pub(crate) fn fixture_impl(args: FixtureAttr, input: ItemFn) -> Result<TokenStre
 
             fn setup_matrix(
                 ctx: &mut ::rustest::TestContext
-            ) -> std::result::Result<Vec<::rustest::BuilderCombination<Self::SubBuilders>>, ::rustest::FixtureCreationError> {
+            ) -> Vec<::rustest::BuilderCombination<Self::SubBuilders>> {
                 use ::rustest::FixtureBuilder;
-                let fixtures_matrix = ::rustest::FixtureMatrix::new()#(.feed(#sub_fixtures_builders::setup(ctx)?))*;
-                Ok(fixtures_matrix.flatten())
+                let fixtures_matrix = ::rustest::FixtureMatrix::new()#(.feed(#sub_fixtures_builders::setup(ctx)))*;
+                fixtures_matrix.flatten()
             }
             fn build_fixt(
                 #sub_fixtures_call_args : ::rustest::CallArgs<Self::SubFixtures>,

--- a/rustest-macro/src/test.rs
+++ b/rustest-macro/src/test.rs
@@ -104,7 +104,7 @@ pub(crate) fn test_impl(args: TestAttr, input: ItemFn) -> Result<TokenStream, To
                         use ::rustest::TestName;
                         let name = c.name();
                         let runner_gen = Box::new(move || {
-                            c.call(move |#sub_fixtures_call_args| -> std::result::Result<Box<::rustest::TestRunner>, _> {
+                            c.call(move |#sub_fixtures_call_args| -> ::rustest::FixtureCreationResult<Box<::rustest::TestRunner>> {
                                 Ok(
                                     Box::new(|| #ident::test(#(#sub_fixtures_inputs),*).into_error()),
                                 )

--- a/rustest-macro/src/test.rs
+++ b/rustest-macro/src/test.rs
@@ -84,13 +84,12 @@ pub(crate) fn test_impl(args: TestAttr, input: ItemFn) -> Result<TokenStream, To
                 #param_fixture_def
                 pub(super) #sig #block
 
-                pub fn #test_generator_ident(ctx: &mut ::rustest::TestContext)
-                    -> ::std::result::Result<Vec<::rustest::Test>, ::rustest::FixtureCreationError> {
+                pub fn #test_generator_ident(ctx: &mut ::rustest::TestContext) -> Vec<::rustest::Test> {
                     use ::rustest::{FixtureBuilder, IntoError, BuilderCall};
 
                     // We have to call build a Test per combination of fixtures.
                     // Lets build a fixture_matrix.
-                    let fixtures_matrix = ::rustest::FixtureMatrix::new()#(.feed(#sub_fixtures_builders::setup(ctx)?))*;
+                    let fixtures_matrix = ::rustest::FixtureMatrix::new()#(.feed(#sub_fixtures_builders::setup(ctx)))*;
                     let combinations = fixtures_matrix.flatten();
 
                     // Append a fixture identifier to test name if we have multiple fixtures instances
@@ -111,10 +110,10 @@ pub(crate) fn test_impl(args: TestAttr, input: ItemFn) -> Result<TokenStream, To
                                 )
                             })
                         });
-                        Ok(::rustest::Test::new(test_name(name), #is_xfail, runner_gen))
+                        ::rustest::Test::new(test_name(name), #is_xfail, runner_gen)
                     })
-                    .collect::<::std::result::Result<Vec<_>, _>>()?;
-                    Ok(tests)
+                    .collect::<Vec<_>>();
+                    tests
                 }
             }
 

--- a/rustest-macro/src/utils.rs
+++ b/rustest-macro/src/utils.rs
@@ -116,7 +116,7 @@ pub(crate) fn gen_param_fixture(
                     #expr.into_iter().map(|i| Self::new(i)).collect()
                 }
 
-                fn build(&self) -> std::result::Result<Self::Fixt, ::rustest::FixtureCreationError> {
+                fn build(&self) -> ::rustest::FixtureCreationResult<Self::Fixt> {
                     Ok(Param(self.0.clone()))
                 }
             }

--- a/rustest-macro/src/utils.rs
+++ b/rustest-macro/src/utils.rs
@@ -112,8 +112,8 @@ pub(crate) fn gen_param_fixture(
                 type Fixt = Param;
                 const SCOPE : ::rustest::FixtureScope = ::rustest::FixtureScope::Test;
 
-                fn setup(ctx: &mut ::rustest::TestContext) -> std::result::Result<Vec<Self>, ::rustest::FixtureCreationError> {
-                    Ok(#expr.into_iter().map(|i| Self::new(i)).collect())
+                fn setup(ctx: &mut ::rustest::TestContext) -> Vec<Self> {
+                    #expr.into_iter().map(|i| Self::new(i)).collect()
                 }
 
                 fn build(&self) -> std::result::Result<Self::Fixt, ::rustest::FixtureCreationError> {

--- a/rustest-testing/src/bin/ignored_test.rs
+++ b/rustest-testing/src/bin/ignored_test.rs
@@ -1,0 +1,45 @@
+use core::assert_eq;
+
+use rustest::{test, *};
+
+#[fixture]
+fn Number() -> u32 {
+    eprintln!("BUILD Number");
+    5
+}
+
+#[test]
+fn test_number(number: Number) {
+    eprintln!("TEST test_number");
+    assert_eq!(*number, 5);
+}
+
+#[test]
+#[ignore]
+fn test_ignored_number(number: Number) {
+    eprintln!("TEST test_ignored_number");
+    assert_eq!(*number, 5);
+}
+
+#[fixture(params:u32 = [5,6,42])]
+fn ParamNumber(Param(n): Param) -> (u32, u32) {
+    eprintln!("BUILD ParamNumber");
+    (n, n * 2)
+}
+
+#[test]
+fn test_param_number(number: ParamNumber) {
+    let (input, expected) = *number;
+    eprintln!("TEST test_param_number");
+    assert_eq!(input * 2, expected);
+}
+
+#[test(ignore)]
+fn test_ignored_param_number(number: ParamNumber) {
+    let (input, expected) = *number;
+    eprintln!("TEST test_ignored_param_number");
+    assert_eq!(input * 2, expected);
+}
+
+#[main]
+fn main() {}

--- a/rustest-testing/src/bin/ignored_test.rs
+++ b/rustest-testing/src/bin/ignored_test.rs
@@ -41,5 +41,16 @@ fn test_ignored_param_number(number: ParamNumber) {
     assert_eq!(input * 2, expected);
 }
 
+fn should_ignore() -> bool {
+    std::env::var_os("IGNORE_TEST").is_some()
+}
+
+#[test]
+#[ignore = should_ignore]
+fn test_conditional_ignore(number: Number) {
+    eprintln!("TEST test_conditional_ignore");
+    assert_eq!(*number, 5);
+}
+
 #[main]
 fn main() {}

--- a/rustest-testing/tests/ignored_test.rs
+++ b/rustest-testing/tests/ignored_test.rs
@@ -1,0 +1,278 @@
+use regex::Regex;
+use std::collections::HashMap;
+use std::process::Output;
+use std::sync::LazyLock;
+
+fn run(options: Option<&[&str]>) -> std::io::Result<std::process::Output> {
+    let exec = env!("CARGO_BIN_EXE_ignored_test");
+    let mut command = std::process::Command::new(&exec);
+    command.env("NO_COLOR", "1");
+    options.map(|options| {
+        for opt in options {
+            command.arg(opt);
+        }
+    });
+    command.output()
+}
+
+#[derive(Default, Debug, PartialEq)]
+struct TestResult {
+    pub tested: usize,
+    pub passed: usize,
+    pub failed: usize,
+    pub ignored: usize,
+    pub measured: usize,
+    pub filtered_out: usize,
+}
+
+struct TestCollector {
+    output: Output,
+    counter: HashMap<Vec<u8>, usize>,
+    result: TestResult,
+}
+
+impl TestCollector {
+    fn collect(output: Output) -> Self {
+        let mut result: TestResult = Default::default();
+        let mut counter = HashMap::new();
+        let mut parse_line = |line: &[u8]| {
+            if line.starts_with(b"running ") {
+                let l = String::from_utf8_lossy(line);
+                println!("{}", l);
+                static RE: LazyLock<Regex> = LazyLock::new(|| {
+                    Regex::new(r"running (?<tested>[[:digit:]]+) tests?").unwrap()
+                });
+                let caps = RE.captures(&l).unwrap();
+                let tested = caps["tested"].parse().unwrap();
+                result = TestResult { tested, ..result }
+            } else if line.starts_with(b"test result:") {
+                let l = String::from_utf8_lossy(line);
+                static RE: LazyLock<Regex> = LazyLock::new(|| {
+                    let sub_regex = ["passed", "failed", "ignored", "measured", "filtered out"]
+                        .into_iter()
+                        .map(|v| format!("(?<{}>[[:digit:]]+) {v};", v.replace(" ", "_")))
+                        .collect::<Vec<_>>()
+                        .join(" ");
+                    Regex::new(&format!("test result: (ok|failed). {sub_regex} finished in [[:digit:]]+.[[:digit:]]+s")).unwrap()
+                });
+                let caps = RE.captures(&l).unwrap();
+                let passed = caps["passed"].parse().unwrap();
+                let failed = caps["failed"].parse().unwrap();
+                let ignored = caps["ignored"].parse().unwrap();
+                let measured = caps["measured"].parse().unwrap();
+                let filtered_out = caps["filtered_out"].parse().unwrap();
+                result = TestResult {
+                    passed,
+                    failed,
+                    ignored,
+                    measured,
+                    filtered_out,
+                    ..result
+                };
+            } else if !line.is_empty() {
+                counter
+                    .entry(line.to_vec())
+                    .and_modify(|count| *count += 1)
+                    .or_insert(1);
+            }
+        };
+        for line in output.stdout.split(|char| *char == b'\n') {
+            parse_line(line);
+        }
+        for line in output.stderr.split(|char| *char == b'\n') {
+            parse_line(line);
+        }
+        Self {
+            counter,
+            result,
+            output,
+        }
+    }
+    fn check(&mut self, line: &[u8], count: usize) {
+        if let Some((_, c)) = self.counter.remove_entry(line) {
+            if c != count {
+                eprintln!("Stdout : {}", String::from_utf8_lossy(&self.output.stdout));
+                eprintln!("Stderr : {}", String::from_utf8_lossy(&self.output.stderr));
+                panic!(
+                    "Check failed: {c} != {count} for line {}",
+                    String::from_utf8_lossy(line)
+                );
+            }
+        } else {
+            if count != 0 {
+                eprintln!("Stdout : {}", String::from_utf8_lossy(&self.output.stdout));
+                eprintln!("Stderr : {}", String::from_utf8_lossy(&self.output.stderr));
+                panic!(
+                    "Check failed: Expected {count} line {}",
+                    String::from_utf8_lossy(line)
+                );
+            }
+        }
+    }
+    fn check_end(&mut self, result: TestResult) {
+        assert_eq!(self.result, result);
+        if self.counter.len() != 0 {
+            let count = self.counter.len();
+            let left_over = self
+                .counter
+                .drain()
+                .map(|(l, _c)| format!("|{}|", String::from_utf8_lossy(&l)))
+                .collect::<Vec<_>>()
+                .join("\n");
+            panic!("Some leftover {count}: {left_over}");
+        }
+    }
+}
+
+#[test]
+fn test_output() {
+    let output = run(None).unwrap();
+    let mut dict = TestCollector::collect(output);
+
+    dict.check(b"BUILD Number", 1);
+    dict.check(b"BUILD ParamNumber", 3);
+    dict.check(b"TEST test_number", 1);
+    dict.check(b"TEST test_param_number", 3);
+    dict.check(b"test test_number                               ... ok", 1);
+    dict.check(
+        b"test test_ignored_number                       ... ignored",
+        1,
+    );
+    dict.check(b"test test_param_number[ParamNumber:5]          ... ok", 1);
+    dict.check(b"test test_param_number[ParamNumber:6]          ... ok", 1);
+    dict.check(b"test test_param_number[ParamNumber:42]         ... ok", 1);
+    dict.check(
+        b"test test_ignored_param_number[ParamNumber:5]  ... ignored",
+        1,
+    );
+    dict.check(
+        b"test test_ignored_param_number[ParamNumber:6]  ... ignored",
+        1,
+    );
+    dict.check(
+        b"test test_ignored_param_number[ParamNumber:42] ... ignored",
+        1,
+    );
+    dict.check_end(TestResult {
+        tested: 8,
+        passed: 4,
+        ignored: 4,
+        ..Default::default()
+    });
+}
+
+#[test]
+fn test_output_param_only() {
+    let output = run(Some(&["test_param_number"])).unwrap();
+    let mut dict = TestCollector::collect(output);
+
+    dict.check(b"BUILD Number", 0);
+    dict.check(b"BUILD ParamNumber", 3);
+    dict.check(b"TEST test_number", 0);
+    dict.check(b"TEST test_param_number", 3);
+    dict.check(b"test test_number                               ... ok", 0);
+    dict.check(
+        b"test test_ignored_number                       ... ignored",
+        0,
+    );
+    dict.check(b"test test_param_number[ParamNumber:5]  ... ok", 1);
+    dict.check(b"test test_param_number[ParamNumber:6]  ... ok", 1);
+    dict.check(b"test test_param_number[ParamNumber:42] ... ok", 1);
+    dict.check(
+        b"test test_ignored_param_number[ParamNumber:5]  ... ignored",
+        0,
+    );
+    dict.check(
+        b"test test_ignored_param_number[ParamNumber:6]  ... ignored",
+        0,
+    );
+    dict.check(
+        b"test test_ignored_param_number[ParamNumber:42] ... ignored",
+        0,
+    );
+    dict.check_end(TestResult {
+        tested: 3,
+        passed: 3,
+        filtered_out: 5,
+        ..Default::default()
+    });
+}
+
+#[test]
+fn test_output_ignored() {
+    let output = run(Some(&["--include-ignored"])).unwrap();
+    let mut dict = TestCollector::collect(output);
+
+    dict.check(b"BUILD Number", 2);
+    dict.check(b"BUILD ParamNumber", 6);
+    dict.check(b"TEST test_number", 1);
+    dict.check(b"TEST test_ignored_number", 1);
+    dict.check(b"TEST test_param_number", 3);
+    dict.check(b"TEST test_ignored_param_number", 3);
+    dict.check(b"test test_number                               ... ok", 1);
+    dict.check(b"test test_ignored_number                       ... ok", 1);
+    dict.check(b"test test_param_number[ParamNumber:5]          ... ok", 1);
+    dict.check(b"test test_param_number[ParamNumber:6]          ... ok", 1);
+    dict.check(b"test test_param_number[ParamNumber:42]         ... ok", 1);
+    dict.check(b"test test_ignored_param_number[ParamNumber:5]  ... ok", 1);
+    dict.check(b"test test_ignored_param_number[ParamNumber:6]  ... ok", 1);
+    dict.check(b"test test_ignored_param_number[ParamNumber:42] ... ok", 1);
+    dict.check_end(TestResult {
+        tested: 8,
+        passed: 8,
+        filtered_out: 0,
+        ..Default::default()
+    });
+}
+
+#[test]
+fn test_output_ignored_only() {
+    let output = run(Some(&["--ignored"])).unwrap();
+    let mut dict = TestCollector::collect(output);
+
+    dict.check(b"BUILD Number", 1);
+    dict.check(b"BUILD ParamNumber", 3);
+    dict.check(b"TEST test_number", 0);
+    dict.check(b"TEST test_ignored_number", 1);
+    dict.check(b"TEST test_param_number", 0);
+    dict.check(b"TEST test_ignored_param_number", 3);
+    dict.check(b"test test_number                               ... ok", 0);
+    dict.check(b"test test_ignored_number                       ... ok", 1);
+    dict.check(b"test test_param_number[ParamNumber:5]          ... ok", 0);
+    dict.check(b"test test_param_number[ParamNumber:6]          ... ok", 0);
+    dict.check(b"test test_param_number[ParamNumber:42]         ... ok", 0);
+    dict.check(b"test test_ignored_param_number[ParamNumber:5]  ... ok", 1);
+    dict.check(b"test test_ignored_param_number[ParamNumber:6]  ... ok", 1);
+    dict.check(b"test test_ignored_param_number[ParamNumber:42] ... ok", 1);
+    dict.check_end(TestResult {
+        tested: 4,
+        passed: 4,
+        filtered_out: 4,
+        ..Default::default()
+    });
+}
+
+#[test]
+fn test_output_list() {
+    let output = run(Some(&["--list"])).unwrap();
+    assert_eq!(
+        output.stdout,
+        b"test_number: test
+test_ignored_number: test
+test_param_number[ParamNumber:5]: test
+test_param_number[ParamNumber:6]: test
+test_param_number[ParamNumber:42]: test
+test_ignored_param_number[ParamNumber:5]: test
+test_ignored_param_number[ParamNumber:6]: test
+test_ignored_param_number[ParamNumber:42]: test
+",
+        "{}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    assert_eq!(
+        output.stderr,
+        b"",
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}

--- a/rustest/src/fixture.rs
+++ b/rustest/src/fixture.rs
@@ -57,8 +57,8 @@ pub trait FixtureBuilder: Duplicate + TestName {
     ///
     /// # Returns
     ///
-    /// A result containing a vector of fixtures or a `FixtureCreationError`.
-    fn setup(ctx: &mut TestContext) -> std::result::Result<Vec<Self>, FixtureCreationError>
+    /// A result containing a vector of builders.
+    fn setup(ctx: &mut TestContext) -> Vec<Self>
     where
         Self: Sized;
 

--- a/rustest/src/fixture.rs
+++ b/rustest/src/fixture.rs
@@ -15,6 +15,8 @@ pub struct FixtureCreationError {
     pub error: Box<dyn std::error::Error>,
 }
 
+pub type FixtureCreationResult<T> = Result<T, FixtureCreationError>;
+
 impl FixtureCreationError {
     /// Creates a new `FixtureCreationError`.
     ///
@@ -62,7 +64,7 @@ pub trait FixtureBuilder: Duplicate + TestName {
     where
         Self: Sized;
 
-    fn build(&self) -> std::result::Result<Self::Fixt, FixtureCreationError>
+    fn build(&self) -> FixtureCreationResult<Self::Fixt>
     where
         Self: Sized;
 }
@@ -198,9 +200,9 @@ impl<V, B> From<BuilderCombination<B>> for LazyValue<V, B> {
 }
 
 impl<V: Clone, B> LazyValue<V, B> {
-    pub fn get<F, T>(&mut self, f: F) -> Result<V, FixtureCreationError>
+    pub fn get<F, T>(&mut self, f: F) -> FixtureCreationResult<V>
     where
-        F: Fn(CallArgs<T>) -> Result<V, FixtureCreationError>,
+        F: Fn(CallArgs<T>) -> FixtureCreationResult<V>,
         BuilderCombination<B>: BuilderCall<T>,
     {
         if let LazyValue::Builders(b) = self {

--- a/rustest/src/fixture_builder.rs
+++ b/rustest/src/fixture_builder.rs
@@ -14,9 +14,7 @@ pub trait FixtureDef {
     type SubFixtures;
     type SubBuilders;
     const SCOPE: FixtureScope;
-    fn setup_matrix(
-        ctx: &mut crate::TestContext,
-    ) -> Result<Vec<BuilderCombination<Self::SubBuilders>>, FixtureCreationError>;
+    fn setup_matrix(ctx: &mut crate::TestContext) -> Vec<BuilderCombination<Self::SubBuilders>>;
 
     fn build_fixt(
         args: CallArgs<Self::SubFixtures>,
@@ -75,21 +73,19 @@ where
     type Type = <Def::Fixt as Fixture>::Type;
     const SCOPE: FixtureScope = Def::SCOPE;
 
-    fn setup(
-        ctx: &mut crate::TestContext,
-    ) -> std::result::Result<Vec<Self>, crate::FixtureCreationError> {
+    fn setup(ctx: &mut crate::TestContext) -> Vec<Self> {
         if let Some(b) = ctx.get() {
-            return Ok(b);
+            return b;
         }
         // We have to call this function for each combination of its fixtures.
-        let builders = Def::setup_matrix(ctx)?;
+        let builders = Def::setup_matrix(ctx);
         let inners = builders
             .into_iter()
             .map(|b| Self::new(b))
             .collect::<Vec<_>>();
 
         ctx.add::<Self>(inners.duplicate());
-        Ok(inners)
+        inners
     }
 
     fn build(&self) -> std::result::Result<Self::Fixt, crate::FixtureCreationError> {

--- a/rustest/src/fixture_builder.rs
+++ b/rustest/src/fixture_builder.rs
@@ -5,7 +5,7 @@ use std::{
 
 use crate::{
     BuildableFixture, BuilderCall, BuilderCombination, CallArgs, Duplicate, Fixture,
-    FixtureBuilder, FixtureCreationError, FixtureScope, LazyValue, SharedFixtureValue, TeardownFn,
+    FixtureBuilder, FixtureCreationResult, FixtureScope, LazyValue, SharedFixtureValue, TeardownFn,
     TestName,
 };
 
@@ -18,7 +18,7 @@ pub trait FixtureDef {
 
     fn build_fixt(
         args: CallArgs<Self::SubFixtures>,
-    ) -> Result<<Self::Fixt as Fixture>::Type, FixtureCreationError>;
+    ) -> FixtureCreationResult<<Self::Fixt as Fixture>::Type>;
 
     fn teardown() -> Option<Arc<TeardownFn<<Self::Fixt as Fixture>::Type>>>;
 }
@@ -88,7 +88,7 @@ where
         inners
     }
 
-    fn build(&self) -> std::result::Result<Self::Fixt, crate::FixtureCreationError> {
+    fn build(&self) -> FixtureCreationResult<Self::Fixt> {
         let inner = self
             .inner
             .lock()

--- a/rustest/src/fixture_matrix.rs
+++ b/rustest/src/fixture_matrix.rs
@@ -380,7 +380,7 @@ mod tests {
         type Fixt = DummyFixture<T>;
         const SCOPE: FixtureScope = FixtureScope::Unique;
 
-        fn setup(_ctx: &mut TestContext) -> std::result::Result<Vec<Self>, FixtureCreationError>
+        fn setup(_ctx: &mut TestContext) -> Vec<Self>
         where
             Self: Sized,
         {

--- a/rustest/src/fixture_matrix.rs
+++ b/rustest/src/fixture_matrix.rs
@@ -1,6 +1,6 @@
 use std::cmp::PartialEq;
 
-use super::{FixtureBuilder, FixtureCreationError, TestName};
+use super::{FixtureBuilder, FixtureCreationResult, TestName};
 
 pub struct CallArgs<Types>(pub Types);
 
@@ -16,9 +16,9 @@ where
 }
 
 pub trait BuilderCall<Args> {
-    fn call<F, Output>(self, f: F) -> Result<Output, FixtureCreationError>
+    fn call<F, Output>(self, f: F) -> FixtureCreationResult<Output>
     where
-        F: FnOnce(CallArgs<Args>) -> Result<Output, FixtureCreationError>;
+        F: FnOnce(CallArgs<Args>) -> FixtureCreationResult<Output>;
 }
 
 macro_rules! impl_fixture_combination_call {
@@ -28,9 +28,9 @@ macro_rules! impl_fixture_combination_call {
             fn call<F, Output>(
                 self,
                 f: F,
-            ) -> Result<Output, FixtureCreationError>
+            ) -> FixtureCreationResult<Output>
                 where
-                F: FnOnce(CallArgs<()>) -> Result<Output, FixtureCreationError>,
+                F: FnOnce(CallArgs<()>) -> FixtureCreationResult<Output>,
             {
                 f(CallArgs(()))
             }
@@ -44,9 +44,9 @@ macro_rules! impl_fixture_combination_call {
             fn call<F, Output>(
                 self,
                 f: F,
-            ) -> Result<Output, FixtureCreationError>
+            ) -> FixtureCreationResult<Output>
                 where
-                F: FnOnce(CallArgs<($($types::Fixt),+,)>) -> Result<Output, FixtureCreationError>,
+                F: FnOnce(CallArgs<($($types::Fixt),+,)>) -> FixtureCreationResult<Output>,
             {
                 let ($($names),+, ) = self.0;
                 let call_args = CallArgs(($($names.build()?),+,));
@@ -357,10 +357,7 @@ mod tests {
     use core::{option::Option::None, unimplemented};
 
     use super::*;
-    use crate::{
-        Duplicate, Fixture, FixtureBuilder, FixtureCreationError, FixtureRegistry, FixtureScope,
-        TestContext,
-    };
+    use crate::{Duplicate, Fixture, FixtureBuilder, FixtureRegistry, FixtureScope, TestContext};
 
     struct DummyFixture<T>(T);
 
@@ -387,7 +384,7 @@ mod tests {
             unimplemented!()
         }
 
-        fn build(&self) -> Result<DummyFixture<T>, FixtureCreationError> {
+        fn build(&self) -> FixtureCreationResult<DummyFixture<T>> {
             Ok(DummyFixture(self.0))
         }
     }

--- a/rustest/src/lib.rs
+++ b/rustest/src/lib.rs
@@ -125,8 +125,8 @@ use fixture::FixtureRegistry;
 #[doc(hidden)]
 pub use fixture::SharedFixtureValue;
 pub use fixture::{
-    BuildableFixture, Fixture, FixtureBuilder, FixtureCreationError, FixtureScope, LazyValue,
-    SubFixture, TeardownFn,
+    BuildableFixture, Fixture, FixtureBuilder, FixtureCreationError, FixtureCreationResult,
+    FixtureScope, LazyValue, SubFixture, TeardownFn,
 };
 pub use fixture_builder::{Builder, FixtureDef};
 pub use fixture_matrix::{BuilderCall, BuilderCombination, CallArgs, Duplicate, FixtureMatrix};

--- a/rustest/src/test.rs
+++ b/rustest/src/test.rs
@@ -84,6 +84,7 @@ pub struct Test {
     name: String,
     runner: Box<TestGenerator>,
     xfail: bool,
+    ignore: bool,
 }
 
 fn setup_gtest() {
@@ -109,10 +110,16 @@ fn collect_gtest(test_result: InnerTestResult) -> InnerTestResult {
 
 impl Test {
     /// Build a new test.
-    pub fn new(name: impl Into<String>, xfail: bool, runner: Box<TestGenerator>) -> Self {
+    pub fn new(
+        name: impl Into<String>,
+        xfail: bool,
+        ignore: bool,
+        runner: Box<TestGenerator>,
+    ) -> Self {
         Self {
             name: name.into(),
             xfail,
+            ignore,
             runner,
         }
     }
@@ -149,13 +156,16 @@ impl Test {
 impl From<Test> for libtest_mimic::Trial {
     fn from(test: Test) -> Self {
         let xfail = test.xfail;
+        let ignore = test.ignore;
         let mimic_test = Self::test(test.name.clone(), move || test.run());
 
-        if xfail {
+        let mimic_test = if xfail {
             mimic_test.with_kind("XFAIL")
         } else {
             mimic_test
-        }
+        };
+
+        mimic_test.with_ignored_flag(ignore)
     }
 }
 

--- a/rustest/src/test.rs
+++ b/rustest/src/test.rs
@@ -194,7 +194,7 @@ impl<'a> TestContext<'a> {
         reg.get::<B>()
     }
 
-    pub fn get_fixture<Fix>(&mut self) -> std::result::Result<Vec<Fix>, FixtureCreationError>
+    pub fn get_fixture<Fix>(&mut self) -> Vec<Fix>
     where
         Fix: FixtureBuilder + Any,
     {

--- a/rustest/src/test.rs
+++ b/rustest/src/test.rs
@@ -46,7 +46,7 @@ pub type LibTestResult = std::result::Result<(), Failed>;
 
 use crate::FixtureBuilder;
 
-use super::{FixtureCreationError, FixtureRegistry, FixtureScope};
+use super::{FixtureCreationResult, FixtureRegistry, FixtureScope};
 use std::any::Any;
 
 #[doc(hidden)]
@@ -77,8 +77,7 @@ impl<T> IntoError for googletest::Result<T> {
 }
 
 pub type TestRunner = dyn FnOnce() -> InnerTestResult + std::panic::UnwindSafe + 'static;
-pub type TestGenerator =
-    dyn FnOnce() -> std::result::Result<Box<TestRunner>, FixtureCreationError> + Send + 'static;
+pub type TestGenerator = dyn FnOnce() -> FixtureCreationResult<Box<TestRunner>> + Send + 'static;
 
 /// An actual test run by rustest
 pub struct Test {


### PR DESCRIPTION
We can now add a `ignore` attribute to a test to make `cargo test` ignored as in std test:

```rust
#[test]
#[ignore]
fn test() {
    ...
}
```

But we can also conditionally ignore the test :

```rust
#[test]
#[ignore = || std::env::var_os("IGNORE_TEST").is_some()]
fn test() {
   ...
}
``` 

Fixes #9 