### PR TITLE
Introduce ParamName

### DIFF
--- a/rustest-macro/src/utils.rs
+++ b/rustest-macro/src/utils.rs
@@ -91,26 +91,35 @@ pub(crate) fn gen_param_fixture(
         };
         quote! {
             #visibility struct Param(pub #param_type);
-            #visibility struct ParamBuilder(#param_type);
+            #visibility struct ParamBuilder {
+                v: #param_type,
+                name: String
+            }
             impl ParamBuilder
             {
-                fn new(inner: #param_type) -> Self {
-                    Self(inner)
+                fn new<T>(inner: T) -> Self
+                where
+                    T: ::rustest::ToParamName<#param_type>
+                {
+                    let (v, name) = inner.into();
+                    let name = format!(#test_name_format, name);
+                    Self{v, name}
                 }
             }
 
             impl ::rustest::Duplicate for ParamBuilder {
                 fn duplicate(&self) -> Self {
-                    Self(self.0.clone())
+                    Self{
+                        v: self.v.clone(),
+                        name: self.name.clone()
+                    }
                 }
             }
 
             impl ::rustest::TestName for ParamBuilder
             {
                 fn name(&self) -> Option<String> {
-                    use ::rustest::ParamName;
-                    // Param value should always be display
-                    Some(format!(#test_name_format, self.0.param_name()))
+                    Some(self.name.clone())
                 }
             }
 
@@ -121,11 +130,11 @@ pub(crate) fn gen_param_fixture(
                 const SCOPE : ::rustest::FixtureScope = ::rustest::FixtureScope::Test;
 
                 fn setup(ctx: &mut ::rustest::TestContext) -> Vec<Self> {
-                    #expr.into_iter().map(|i| Self::new(i)).collect()
+                    #expr.into_iter().map(Self::new).collect()
                 }
 
                 fn build(&self) -> ::rustest::FixtureCreationResult<Self::Fixt> {
-                    Ok(Param(self.0.clone()))
+                    Ok(Param(self.v.clone()))
                 }
             }
 

--- a/rustest-macro/src/utils.rs
+++ b/rustest-macro/src/utils.rs
@@ -108,8 +108,9 @@ pub(crate) fn gen_param_fixture(
             impl ::rustest::TestName for ParamBuilder
             {
                 fn name(&self) -> Option<String> {
+                    use ::rustest::ParamName;
                     // Param value should always be display
-                    Some(format!(#test_name_format, self.0.name().unwrap()))
+                    Some(format!(#test_name_format, self.0.param_name()))
                 }
             }
 

--- a/rustest-testing/src/bin/simple_test.rs
+++ b/rustest-testing/src/bin/simple_test.rs
@@ -52,5 +52,8 @@ fn test_param_global_number_bis(number: ParamGlobalNumber) {
     assert_eq!(input * 2, expected);
 }
 
+#[test(params:u32=[(5, "five"), (6, "six")])]
+fn test_named(Param(_n): Param) {}
+
 #[main]
 fn main() {}

--- a/rustest-testing/tests/simple_test.rs
+++ b/rustest-testing/tests/simple_test.rs
@@ -189,9 +189,17 @@ fn test_output() {
         b"test test_param_global_number_bis[ParamGlobalNumber:42] ... ok",
         1,
     );
+    dict.check(
+        b"test test_named[five]                                   ... ok",
+        1,
+    );
+    dict.check(
+        b"test test_named[six]                                    ... ok",
+        1,
+    );
     dict.check_end(TestResult {
-        tested: 13,
-        passed: 13,
+        tested: 15,
+        passed: 15,
         ..Default::default()
     });
 }
@@ -216,7 +224,7 @@ fn test_output_param_only() {
     dict.check_end(TestResult {
         tested: 6,
         passed: 6,
-        filtered_out: 7,
+        filtered_out: 9,
         ..Default::default()
     });
 }
@@ -239,6 +247,8 @@ test_param_global_number[ParamGlobalNumber:42]: test
 test_param_global_number_bis[ParamGlobalNumber:5]: test
 test_param_global_number_bis[ParamGlobalNumber:6]: test
 test_param_global_number_bis[ParamGlobalNumber:42]: test
+test_named[five]: test
+test_named[six]: test
 ",
         "{}",
         String::from_utf8_lossy(&output.stdout)

--- a/rustest/src/fixture_matrix.rs
+++ b/rustest/src/fixture_matrix.rs
@@ -543,9 +543,19 @@ mod tests {
 
     #[test]
     fn test_builder_combination_test_name() {
-        let combination = BuilderCombination((5, false, "A text"));
+        struct P<T>(T);
+
+        impl<T> TestName for P<T>
+        where
+            T: crate::ParamName,
+        {
+            fn name(&self) -> Option<String> {
+                Some(self.0.param_name())
+            }
+        }
+        let combination = BuilderCombination((P(5), P(false), P("A text")));
         assert_eq!(combination.name(), Some("[5|false|A text]".into()));
-        let combination = BuilderCombination((5, false, (Box::new(42), vec![5; 3])));
+        let combination = BuilderCombination((P(5), P(false), P((Box::new(42), vec![5; 3]))));
         assert_eq!(combination.name(), Some("[5|false|(42,[5,5,5])]".into()));
     }
 }

--- a/rustest/src/lib.rs
+++ b/rustest/src/lib.rs
@@ -136,7 +136,7 @@ pub use fixture_matrix::{BuilderCall, BuilderCombination, CallArgs, FixtureMatri
 #[doc(hidden)]
 pub use test::{InnerTestResult, IntoError, TestGenerator, TestRunner};
 pub use test::{Result, Test, TestContext};
-pub use test_name::{ParamName, TestName};
+pub use test_name::{ParamName, TestName, ToParamName};
 
 pub use ctor::declarative::ctor;
 

--- a/rustest/src/lib.rs
+++ b/rustest/src/lib.rs
@@ -136,7 +136,7 @@ pub use fixture_matrix::{BuilderCall, BuilderCombination, CallArgs, FixtureMatri
 #[doc(hidden)]
 pub use test::{InnerTestResult, IntoError, TestGenerator, TestRunner};
 pub use test::{Result, Test, TestContext};
-pub use test_name::TestName;
+pub use test_name::{ParamName, TestName};
 
 pub use ctor::declarative::ctor;
 
@@ -469,9 +469,9 @@ pub fn run_tests(test_generators: &[TestGeneratorFn]) -> std::process::ExitCode 
 /// #[derive(Clone)]
 /// pub(crate) struct MyValue(u32);
 ///
-/// impl TestName for MyValue {
-///     fn name(&self) -> Option<String> {
-///         Some(format!("{}", self.0))
+/// impl ParamName for MyValue {
+///     fn param_name(&self) -> String {
+///         format!("{}", self.0)
 ///     }
 /// }
 ///

--- a/rustest/src/test_name.rs
+++ b/rustest/src/test_name.rs
@@ -55,6 +55,32 @@ impl<T: ParamName> ParamName for Option<T> {
     }
 }
 
+pub trait ToParamName<T> {
+    fn into(self) -> (T, String);
+}
+
+impl<T> ToParamName<T> for T
+where
+    T: ParamName,
+{
+    fn into(self) -> (T, String) {
+        let name = self.param_name();
+        (self, name)
+    }
+}
+
+impl<T> ToParamName<T> for (T, String) {
+    fn into(self) -> (T, String) {
+        self
+    }
+}
+
+impl<T> ToParamName<T> for (T, &str) {
+    fn into(self) -> (T, String) {
+        (self.0, self.1.to_owned())
+    }
+}
+
 impl ParamName for str {
     fn param_name(&self) -> String {
         self.to_owned()

--- a/rustest/src/test_name.rs
+++ b/rustest/src/test_name.rs
@@ -1,5 +1,6 @@
 use std::sync::Mutex;
 
+#[doc(hidden)]
 /// A trait to get the name of a test when we have multiple combination.
 ///
 /// `TestName` is used to provide a name for a test or a part of it.
@@ -12,11 +13,23 @@ pub trait TestName {
     fn name(&self) -> Option<String>;
 }
 
+/// A trait to get the name of a param when we have multiple combination.
+///
+/// `ParamName` is used to provide a name for a test.
+pub trait ParamName {
+    /// Returns the name of the parameter.
+    ///
+    /// # Returns
+    ///
+    /// The name of the param as a `String`.
+    fn param_name(&self) -> String;
+}
+
 macro_rules! impl_test_name {
     ($($t:ty),+) => {
-        $(impl TestName for $t {
-            fn name(&self) -> Option<String> {
-                Some(format!("{}", self))
+        $(impl ParamName for $t {
+            fn param_name(&self) -> String {
+                format!("{}", self)
             }
         })+
     };
@@ -26,79 +39,65 @@ impl_test_name!(
     u8, u16, u32, u64, u128, usize, i8, i16, i32, i64, i128, isize, bool, f32, f64, char
 );
 
-impl<T: TestName> TestName for Box<T> {
-    fn name(&self) -> Option<String> {
+impl<T: ParamName> ParamName for Box<T> {
+    fn param_name(&self) -> String {
         use std::ops::Deref;
-        self.deref().name()
+        self.deref().param_name()
     }
 }
 
-impl<T: TestName> TestName for Option<T> {
-    fn name(&self) -> Option<String> {
+impl<T: ParamName> ParamName for Option<T> {
+    fn param_name(&self) -> String {
         match self {
-            Some(v) => v.name(),
-            None => Some("None".to_owned()),
+            Some(v) => v.param_name(),
+            None => "None".to_owned(),
         }
     }
 }
 
-impl TestName for str {
-    fn name(&self) -> Option<String> {
-        Some(self.to_owned())
+impl ParamName for str {
+    fn param_name(&self) -> String {
+        self.to_owned()
     }
 }
 
-impl TestName for &str {
-    fn name(&self) -> Option<String> {
-        Some((*self).to_owned())
+impl ParamName for &str {
+    fn param_name(&self) -> String {
+        (*self).to_owned()
     }
 }
 
-impl TestName for String {
-    fn name(&self) -> Option<String> {
-        Some(self.clone())
+impl ParamName for String {
+    fn param_name(&self) -> String {
+        self.clone()
     }
 }
 
-impl<T: TestName> TestName for Vec<T> {
-    fn name(&self) -> Option<String> {
-        let vec = self.iter().filter_map(|v| v.name()).collect::<Vec<_>>();
-        if vec.is_empty() {
-            None
-        } else {
-            Some(format!("[{}]", vec.join(",")))
-        }
+impl<T: ParamName> ParamName for Vec<T> {
+    fn param_name(&self) -> String {
+        let vec = self.iter().map(|v| v.param_name()).collect::<Vec<_>>();
+        format!("[{}]", vec.join(","))
     }
 }
 
-impl<T: TestName> TestName for Mutex<T> {
-    fn name(&self) -> Option<String> {
-        self.lock().unwrap().name()
-    }
-}
-
-impl TestName for () {
-    fn name(&self) -> Option<String> {
-        None
+impl<T: ParamName> ParamName for Mutex<T> {
+    fn param_name(&self) -> String {
+        self.lock().unwrap().param_name()
     }
 }
 
 macro_rules! impl_fixture_name_tuple {
     (($($types:tt),+), ($($names:ident),+)) => {
 
-        impl< $($types),+ > TestName for ($($types),+,)
+        impl< $($types),+ > ParamName for ($($types),+,)
            where
-                $($types : TestName),+ ,
+                $($types : ParamName),+ ,
         {
-            fn name(&self) -> Option<String> {
+            fn param_name(&self) -> String {
                 let ($($names),+, ) = self;
-                $(let $names = $names.name();)+
-                let vec = vec![$($names),+].into_iter().filter_map(|d|d).collect::<Vec<_>>();
-                if vec.is_empty() {
-                    None
-                } else {
-                    Some(format!("({})", vec.join(",")))
-                }
+                $(let $names = $names.param_name();)+
+                let vec = vec![$($names),+].into_iter().collect::<Vec<_>>();
+                format!("({})", vec.join(","))
             }
         }
     }
@@ -140,150 +139,158 @@ mod tests {
 
     #[test]
     fn test_integers() {
-        assert_eq!(0u8.name(), Some("0".into()));
-        assert_eq!(42u8.name(), Some("42".into()));
-        assert_eq!(0u16.name(), Some("0".into()));
-        assert_eq!(42u16.name(), Some("42".into()));
-        assert_eq!(0u32.name(), Some("0".into()));
-        assert_eq!(42u32.name(), Some("42".into()));
-        assert_eq!(0u64.name(), Some("0".into()));
-        assert_eq!(42u64.name(), Some("42".into()));
-        assert_eq!(0u128.name(), Some("0".into()));
-        assert_eq!(42u128.name(), Some("42".into()));
-        assert_eq!(0usize.name(), Some("0".into()));
-        assert_eq!(42usize.name(), Some("42".into()));
+        assert_eq!(0u8.param_name(), "0".to_owned());
+        assert_eq!(42u8.param_name(), "42".to_owned());
+        assert_eq!(0u16.param_name(), "0".to_owned());
+        assert_eq!(42u16.param_name(), "42".to_owned());
+        assert_eq!(0u32.param_name(), "0".to_owned());
+        assert_eq!(42u32.param_name(), "42".to_owned());
+        assert_eq!(0u64.param_name(), "0".to_owned());
+        assert_eq!(42u64.param_name(), "42".to_owned());
+        assert_eq!(0u128.param_name(), "0".to_owned());
+        assert_eq!(42u128.param_name(), "42".to_owned());
+        assert_eq!(0usize.param_name(), "0".to_owned());
+        assert_eq!(42usize.param_name(), "42".to_owned());
 
-        assert_eq!(0i8.name(), Some("0".into()));
-        assert_eq!(42i8.name(), Some("42".into()));
-        assert_eq!((-42i8).name(), Some("-42".into()));
-        assert_eq!(0i16.name(), Some("0".into()));
-        assert_eq!(42i16.name(), Some("42".into()));
-        assert_eq!((-42i16).name(), Some("-42".into()));
-        assert_eq!(0i32.name(), Some("0".into()));
-        assert_eq!(42i32.name(), Some("42".into()));
-        assert_eq!((-42i32).name(), Some("-42".into()));
-        assert_eq!(0i64.name(), Some("0".into()));
-        assert_eq!(42i64.name(), Some("42".into()));
-        assert_eq!((-42i64).name(), Some("-42".into()));
-        assert_eq!(0i128.name(), Some("0".into()));
-        assert_eq!(42i128.name(), Some("42".into()));
-        assert_eq!((-42i128).name(), Some("-42".into()));
-        assert_eq!(0isize.name(), Some("0".into()));
-        assert_eq!(42isize.name(), Some("42".into()));
-        assert_eq!((-42isize).name(), Some("-42".into()));
+        assert_eq!(0i8.param_name(), "0".to_owned());
+        assert_eq!(42i8.param_name(), "42".to_owned());
+        assert_eq!((-42i8).param_name(), "-42".to_owned());
+        assert_eq!(0i16.param_name(), "0".to_owned());
+        assert_eq!(42i16.param_name(), "42".to_owned());
+        assert_eq!((-42i16).param_name(), "-42".to_owned());
+        assert_eq!(0i32.param_name(), "0".to_owned());
+        assert_eq!(42i32.param_name(), "42".to_owned());
+        assert_eq!((-42i32).param_name(), "-42".to_owned());
+        assert_eq!(0i64.param_name(), "0".to_owned());
+        assert_eq!(42i64.param_name(), "42".to_owned());
+        assert_eq!((-42i64).param_name(), "-42".to_owned());
+        assert_eq!(0i128.param_name(), "0".to_owned());
+        assert_eq!(42i128.param_name(), "42".to_owned());
+        assert_eq!((-42i128).param_name(), "-42".to_owned());
+        assert_eq!(0isize.param_name(), "0".to_owned());
+        assert_eq!(42isize.param_name(), "42".to_owned());
+        assert_eq!((-42isize).param_name(), "-42".to_owned());
     }
 
     #[test]
     fn test_bool() {
-        assert_eq!(true.name(), Some("true".into()));
-        assert_eq!(false.name(), Some("false".into()));
+        assert_eq!(true.param_name(), "true".to_owned());
+        assert_eq!(false.param_name(), "false".to_owned());
     }
 
     #[test]
     fn test_float() {
-        assert_eq!(0.0f32.name(), Some("0".into()));
-        assert_eq!(1.0f32.name(), Some("1".into()));
-        assert_eq!(0.1f32.name(), Some("0.1".into()));
-        assert_eq!(0.1f32.name(), Some("0.1".into()));
-        assert_eq!(3.5f32.name(), Some("3.5".into()));
-        assert_eq!(27f32.name(), Some("27".into()));
-        assert_eq!((-113.75f32).name(), Some("-113.75".into()));
-        assert_eq!(0.0078125f32.name(), Some("0.0078125".into()));
-        assert_eq!(34359738368f32.name(), Some("34359740000".into()));
-        assert_eq!(0f32.name(), Some("0".into()));
-        assert_eq!((-0.0f32).name(), Some("-0".into()));
-        assert_eq!((-1f32).name(), Some("-1".into()));
-        assert_eq!(f32::NAN.name(), Some("NaN".into()));
-        assert_eq!(f32::INFINITY.name(), Some("inf".into()));
-        assert_eq!(f32::NEG_INFINITY.name(), Some("-inf".into()));
+        assert_eq!(0.0f32.param_name(), "0".to_owned());
+        assert_eq!(1.0f32.param_name(), "1".to_owned());
+        assert_eq!(0.1f32.param_name(), "0.1".to_owned());
+        assert_eq!(0.1f32.param_name(), "0.1".to_owned());
+        assert_eq!(3.5f32.param_name(), "3.5".to_owned());
+        assert_eq!(27f32.param_name(), "27".to_owned());
+        assert_eq!((-113.75f32).param_name(), "-113.75".to_owned());
+        assert_eq!(0.0078125f32.param_name(), "0.0078125".to_owned());
+        assert_eq!(34359738368f32.param_name(), "34359740000".to_owned());
+        assert_eq!(0f32.param_name(), "0".to_owned());
+        assert_eq!((-0.0f32).param_name(), "-0".to_owned());
+        assert_eq!((-1f32).param_name(), "-1".to_owned());
+        assert_eq!(f32::NAN.param_name(), "NaN".to_owned());
+        assert_eq!(f32::INFINITY.param_name(), "inf".to_owned());
+        assert_eq!(f32::NEG_INFINITY.param_name(), "-inf".to_owned());
 
-        assert_eq!(0.0f64.name(), Some("0".into()));
-        assert_eq!(1.0f64.name(), Some("1".into()));
-        assert_eq!(0.1f64.name(), Some("0.1".into()));
-        assert_eq!(0.1f64.name(), Some("0.1".into()));
-        assert_eq!(3.5f64.name(), Some("3.5".into()));
-        assert_eq!(27f64.name(), Some("27".into()));
-        assert_eq!((-113.75f64).name(), Some("-113.75".into()));
-        assert_eq!(0.0078125f64.name(), Some("0.0078125".into()));
-        assert_eq!(34359738368f64.name(), Some("34359738368".into()));
-        assert_eq!(0f64.name(), Some("0".into()));
-        assert_eq!((-0.0f64).name(), Some("-0".into()));
-        assert_eq!((-1f64).name(), Some("-1".into()));
-        assert_eq!(f64::NAN.name(), Some("NaN".into()));
-        assert_eq!(f64::INFINITY.name(), Some("inf".into()));
-        assert_eq!(f64::NEG_INFINITY.name(), Some("-inf".into()));
+        assert_eq!(0.0f64.param_name(), "0".to_owned());
+        assert_eq!(1.0f64.param_name(), "1".to_owned());
+        assert_eq!(0.1f64.param_name(), "0.1".to_owned());
+        assert_eq!(0.1f64.param_name(), "0.1".to_owned());
+        assert_eq!(3.5f64.param_name(), "3.5".to_owned());
+        assert_eq!(27f64.param_name(), "27".to_owned());
+        assert_eq!((-113.75f64).param_name(), "-113.75".to_owned());
+        assert_eq!(0.0078125f64.param_name(), "0.0078125".to_owned());
+        assert_eq!(34359738368f64.param_name(), "34359738368".to_owned());
+        assert_eq!(0f64.param_name(), "0".to_owned());
+        assert_eq!((-0.0f64).param_name(), "-0".to_owned());
+        assert_eq!((-1f64).param_name(), "-1".to_owned());
+        assert_eq!(f64::NAN.param_name(), "NaN".to_owned());
+        assert_eq!(f64::INFINITY.param_name(), "inf".to_owned());
+        assert_eq!(f64::NEG_INFINITY.param_name(), "-inf".to_owned());
     }
 
     #[test]
     fn test_char() {
-        assert_eq!('a'.name(), Some("a".into()));
-        assert_eq!('+'.name(), Some("+".into()));
-        assert_eq!('é'.name(), Some("é".into()));
-        assert_eq!('\u{0301}'.name(), Some("\u{301}".into()));
-        assert_eq!(char::REPLACEMENT_CHARACTER.name(), Some("�".into()));
+        assert_eq!('a'.param_name(), "a".to_owned());
+        assert_eq!('+'.param_name(), "+".to_owned());
+        assert_eq!('é'.param_name(), "é".to_owned());
+        assert_eq!('\u{0301}'.param_name(), "\u{301}".to_owned());
+        assert_eq!(char::REPLACEMENT_CHARACTER.param_name(), "�".to_owned());
     }
 
     #[test]
     fn test_str() {
-        assert_eq!("a".name(), Some("a".into()));
-        assert_eq!("+".name(), Some("+".into()));
-        assert_eq!("é".name(), Some("é".into()));
+        assert_eq!("a".param_name(), "a".to_owned());
+        assert_eq!("+".param_name(), "+".to_owned());
+        assert_eq!("é".param_name(), "é".to_owned());
         // This is the letter 'e' followed by a acute accent
-        assert_eq!("é".name(), Some("e\u{301}".into()));
-        assert_eq!("\u{0065}\u{0301}".name(), Some("e\u{301}".into()));
-        assert_eq!("\u{0065}\u{0301}".name(), Some("é".into()));
-        assert_eq!("💯 love: ❤".name(), Some("💯 love: ❤".into()));
+        assert_eq!("é".param_name(), "e\u{301}".to_owned());
+        assert_eq!("\u{0065}\u{0301}".param_name(), "e\u{301}".to_owned());
+        assert_eq!("\u{0065}\u{0301}".param_name(), "é".to_owned());
+        assert_eq!("💯 love: ❤".param_name(), "💯 love: ❤".to_owned());
     }
 
     #[test]
     fn test_string() {
-        assert_eq!(String::from("a").name(), Some("a".into()));
-        assert_eq!(String::from("+").name(), Some("+".into()));
-        assert_eq!(String::from("é").name(), Some("é".into()));
+        assert_eq!(String::from("a").param_name(), "a".to_owned());
+        assert_eq!(String::from("+").param_name(), "+".to_owned());
+        assert_eq!(String::from("é").param_name(), "é".to_owned());
         // This is the letter 'e' followed by a acute accent
-        assert_eq!(String::from("é").name(), Some("e\u{301}".into()));
+        assert_eq!(String::from("é").param_name(), "e\u{301}".to_owned());
         assert_eq!(
-            String::from("\u{0065}\u{0301}").name(),
-            Some("e\u{301}".into())
+            String::from("\u{0065}\u{0301}").param_name(),
+            "e\u{301}".to_owned()
         );
-        assert_eq!(String::from("\u{0065}\u{0301}").name(), Some("é".into()));
-        assert_eq!(String::from("💯 love: ❤").name(), Some("💯 love: ❤".into()));
+        assert_eq!(
+            String::from("\u{0065}\u{0301}").param_name(),
+            "é".to_owned()
+        );
+        assert_eq!(
+            String::from("💯 love: ❤").param_name(),
+            "💯 love: ❤".to_owned()
+        );
     }
 
     #[test]
     fn test_box() {
         let b = Box::new("A text");
-        assert_eq!(b.name(), Some("A text".into()));
+        assert_eq!(b.param_name(), "A text".to_owned());
         let b = Box::new(42585u32);
-        assert_eq!(b.name(), Some("42585".into()));
+        assert_eq!(b.param_name(), "42585".to_owned());
     }
 
     #[test]
     fn test_option() {
-        assert_eq!(None::<u32>.name(), Some("None".into()));
-        assert_eq!(Some(42585u32).name(), Some("42585".into()));
+        assert_eq!(None::<u32>.param_name(), "None".to_owned());
+        assert_eq!(Some(42585u32).param_name(), "42585".to_owned());
     }
 
     #[test]
     fn test_vec() {
-        assert_eq!(Vec::<u32>::new().name(), None);
-        assert_eq!(vec![42585u32].name(), Some("[42585]".into()));
-        assert_eq!(vec![4, 5].name(), Some("[4,5]".into()));
+        assert_eq!(Vec::<u32>::new().param_name(), "[]".to_owned());
+        assert_eq!(vec![42585u32].param_name(), "[42585]".to_owned());
+        assert_eq!(vec![4, 5].param_name(), "[4,5]".to_owned());
     }
 
     #[test]
     fn test_mutex() {
-        assert_eq!(Mutex::new("a text").name(), Some("a text".into()));
+        assert_eq!(Mutex::new("a text").param_name(), "a text".to_owned());
     }
 
     #[test]
     fn test_tuple() {
-        assert_eq!(().name(), None);
-        assert_eq!((5, 6).name(), Some("(5,6)".into()));
-        assert_eq!((5, false, "A text").name(), Some("(5,false,A text)".into()));
+        assert_eq!((5, 6).param_name(), "(5,6)".to_owned());
         assert_eq!(
-            (5, false, (Box::new(42), vec![5; 3])).name(),
-            Some("(5,false,(42,[5,5,5]))".into())
+            (5, false, "A text").param_name(),
+            "(5,false,A text)".to_owned()
+        );
+        assert_eq!(
+            (5, false, (Box::new(42), vec![5; 3])).param_name(),
+            "(5,false,(42,[5,5,5]))".to_owned()
         );
     }
 }


### PR DESCRIPTION
`TestName::name` must return an option as not all BuilderCombination is
parametrized.
But `ParamName::param_name` must return a `String` as it is a non sens
to have a None name.