### PR TITLE
Use AssertUnwindSafe instead of trait UnwindSafe.

### DIFF
--- a/rustest/src/fixture.rs
+++ b/rustest/src/fixture.rs
@@ -7,7 +7,6 @@ use std::{
     any::{Any, TypeId},
     default::Default,
     ops::Deref,
-    panic::{RefUnwindSafe, UnwindSafe},
     sync::Arc,
 };
 
@@ -199,7 +198,7 @@ impl FixtureRegistry {
 /// A type alias for a teardown function.
 ///
 /// The teardown function is called when the fixture is dropped to clean up resources.
-pub type TeardownFn<T> = dyn Fn(&mut T) + Send + RefUnwindSafe + UnwindSafe + Sync;
+pub type TeardownFn<T> = dyn Fn(&mut T) + Send + Sync;
 
 /// A struct that manages the teardown of a fixture.
 ///

--- a/rustest/src/test.rs
+++ b/rustest/src/test.rs
@@ -74,7 +74,7 @@ impl<T> IntoError for googletest::Result<T> {
     }
 }
 
-pub type TestRunner = dyn FnOnce() -> InnerTestResult + std::panic::UnwindSafe + 'static;
+pub type TestRunner = dyn FnOnce() -> InnerTestResult + 'static;
 pub type TestGenerator = dyn FnOnce() -> FixtureCreationResult<Box<TestRunner>> + Send + 'static;
 
 /// An actual test run by rustest
@@ -125,7 +125,7 @@ impl Test {
         setup_gtest();
         let test_runner = (self.runner)()
             .map_err(|e| Failed::from(format!("Fixture {} error: {}", e.fixture_name, e.error)))?;
-        let unwind_result = std::panic::catch_unwind(test_runner);
+        let unwind_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(test_runner));
         let test_result = match unwind_result {
             Ok(Ok(())) => Ok(()),
             Ok(Err(e)) => Err(e),


### PR DESCRIPTION
As specified in the [documentation](https://doc.rust-lang.org/stable/std/panic/trait.UnwindSafe.html), UnwindSafe is mostly an advisory those some invariant may be broken if a panic appears.

Enforcing that all test functions are UnwindSafe can be difficult or impossible depending of what is tested.