### PR TITLE
Rename `ToParamName::into` into `ToParamName::into_param_name`.

### DIFF
--- a/rustest-macro/src/utils.rs
+++ b/rustest-macro/src/utils.rs
@@ -95,7 +95,7 @@ pub(crate) fn gen_param_fixture(
                 where
                     T: ::rustest::ToParamName<#param_type>
                 {
-                    let (v, name) = inner.into();
+                    let (v, name) = inner.into_param_name();
                     let name = format!(#test_name_format, name);
                     Self{v, name}
                 }

--- a/rustest/src/test_name.rs
+++ b/rustest/src/test_name.rs
@@ -56,27 +56,27 @@ impl<T: ParamName> ParamName for Option<T> {
 }
 
 pub trait ToParamName<T> {
-    fn into(self) -> (T, String);
+    fn into_param_name(self) -> (T, String);
 }
 
 impl<T> ToParamName<T> for T
 where
     T: ParamName,
 {
-    fn into(self) -> (T, String) {
+    fn into_param_name(self) -> (T, String) {
         let name = self.param_name();
         (self, name)
     }
 }
 
 impl<T> ToParamName<T> for (T, String) {
-    fn into(self) -> (T, String) {
+    fn into_param_name(self) -> (T, String) {
         self
     }
 }
 
 impl<T> ToParamName<T> for (T, &str) {
-    fn into(self) -> (T, String) {
+    fn into_param_name(self) -> (T, String) {
         (self.0, self.1.to_owned())
     }
 }


### PR DESCRIPTION
This trait is "internally" used but the `into` method may conflict with `Into` trait.
We should see how not make it public, but renaming the method name is a faster workaround.