### PR TITLE
Implement DerefMut for Once fixtures, to allow mutable access to non-Clone fixture resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,46 @@ fn test_number_string_6(text: NumberAsString<TheNumber6>) {
 }
 ```
 
+**Fixture bindings can be mutable**
+
+For fixtures with `scope=once` (the default), the value binding can be `mut`, allowing a test to call methods
+that require `mut self` or `&mut self`.
+
+```rust
+struct Internal { /*...*/ }
+impl Internal {
+    /*...*/
+    fn new() -> Self { /*...*/ }
+    fn set(&mut self, v: u32) { /*...*/ }
+    fn get(&self) -> u32 { /*...*/ }
+}
+
+struct Resource {
+    internal: Internal,
+}
+
+impl Resource {
+    fn set(&mut self, v: u32) {
+        self.internal.set(v)  // Requires `&mut self`
+    }
+    fn get(&self) -> u32 {
+        self.internal.get()
+    }
+}
+
+#[fixture(scope=once)]
+fn AResource() -> Resource {
+    Resource { internal: Internal::new() }
+}
+
+#[test]
+fn resource_test(mut res: AResource) {
+    res.set(42);  // mut binding of `res` enables mutation of value
+    assert_eq!(res.get(), 42);
+}
+```
+
+Other scopes currently do not support this.
 
 **Running Tests:**
 

--- a/rustest-macro/src/fixture.rs
+++ b/rustest-macro/src/fixture.rs
@@ -262,6 +262,19 @@ pub(crate) fn fixture_impl(args: FixtureAttr, input: ItemFn) -> Result<TokenStre
         )
     };
 
+    // Only Once fixtures can be mutable
+    let deref_mut_impl = if let FixtureScope::Once = scope {
+        quote! {
+            impl #impl_generics ::std::ops::DerefMut for #fixture_name #ty_generics #where_clause {
+                fn deref_mut(&mut self) -> &mut Self::Target {
+                    &mut self.inner
+                }
+            }
+        }
+    } else {
+        quote! {}
+    };
+
     Ok(quote! {
         mod #mod_name {
             use super::*;
@@ -294,6 +307,8 @@ pub(crate) fn fixture_impl(args: FixtureAttr, input: ItemFn) -> Result<TokenStre
                 &self.inner
             }
         }
+
+        #deref_mut_impl
     })
 }
 

--- a/rustest/src/fixture.rs
+++ b/rustest/src/fixture.rs
@@ -223,6 +223,12 @@ impl<T> std::ops::Deref for FixtureTeardown<T> {
     }
 }
 
+impl<T> std::ops::DerefMut for FixtureTeardown<T> {
+    fn deref_mut(&mut self) -> &mut T {
+        &mut self.value
+    }
+}
+
 impl<T> Drop for FixtureTeardown<T> {
     fn drop(&mut self) {
         if let Some(t) = self.teardown.take() {

--- a/rustest/tests/test.rs
+++ b/rustest/tests/test.rs
@@ -50,6 +50,22 @@ fn test_fixture_number(number: ANumber) {
     assert_eq!(*number, 5)
 }
 
+// Once Fixtures can be a mutable struct
+struct Simple {
+    x: u32,
+}
+#[fixture(scope=once)]
+fn AStruct() -> Simple {
+    Simple { x: 5 }
+}
+
+// Fixtures deref_mut to their mutable inner value (Box<u32> here).
+#[test]
+fn test_fixture_mut(mut s: AStruct) {
+    s.x += 42;
+    assert_eq!(s.x, 47)
+}
+
 // Fixture's name can be specified with the `name` attribute.
 // The function's name is useless in this case and can be anything.
 #[fixture(name = ANewNumber)]

--- a/rustest/tests/test.rs
+++ b/rustest/tests/test.rs
@@ -59,11 +59,18 @@ fn AStruct() -> Simple {
     Simple { x: 5 }
 }
 
-// Fixtures deref_mut to their mutable inner value (Box<u32> here).
+// Fixtures deref_mut to their mutable inner value (`Simple` struct here).
 #[test]
 fn test_fixture_mut(mut s: AStruct) {
     s.x += 42;
     assert_eq!(s.x, 47)
+}
+
+// Some of the time, this test will run after `test_fixture_mut` and confirm that the fixture value
+// wasn't somehow modified between tests.
+#[test]
+fn test_fixture_mut_isolated(s: AStruct) {
+    assert_eq!(s.x, 5);
 }
 
 // Fixture's name can be specified with the `name` attribute.


### PR DESCRIPTION
Typically, if a test needs mutable access to a fixture, the test can _clone_ the fixture value and rebind it as mutable:

```rust
#[test]
fn test_something(my_fixture: MyFixture) {
    let mut my_fixture = (*my_fixture).clone();
    my_fixture.set_something(42);
    // ...
```
This is necessary when rustest is used in an embedded application, where access to hardware may require mutable access to a resource held by the fixture (e.g. an I2C bus).

Unfortunately, mostly due to HAL restrictions, sometimes a fixture isn't trivially `Clone`, so this is not possible without additional interior mutability wrappers around the resources. This is significant additional complexity just to provide test ability.

This PR introduces a simple implementation of `DerefMut` for `Once` fixtures, avoiding a `.clone()` and allowing this:

```rust
#[test]
fn test_something(mut my_fixture: MyFixture) {
    my_fixture.set_something(42);
    // ...
```

It might make some sense for shared or global fixtures to be `DerefMut` too, but the solution is more complex, and will involve locking. So only `Once` fixtures have this trait implemented by the `#[fixture]` macro in this PR.
